### PR TITLE
Install Puppet 3.8.x on hosts

### DIFF
--- a/tools/bootstrap
+++ b/tools/bootstrap
@@ -9,4 +9,4 @@ if ! dpkg -l puppetlabs-release >/dev/null; then
   apt-get update -qq
 fi
 
-apt-get install -y -qq --no-upgrade ruby1.9.1 puppet='3.2.*' puppet-common='3.2.*'
+apt-get install -y -qq --no-upgrade ruby1.9.1 puppet='3.8.*' puppet-common='3.8.*'


### PR DESCRIPTION
In 21ba35f, this repository was upgraded to 3.8.x, but this file wasn't.
That means that any changes not backwards compatible won't have been able to
be provisioned, and Apt repositories queried by hosts for packages to
install matching the 3.2.* matcher have returned no packages.

Fixes this.